### PR TITLE
Merge anonymize button into main

### DIFF
--- a/public/openapi/write/posts/pid.yaml
+++ b/public/openapi/write/posts/pid.yaml
@@ -64,6 +64,8 @@ get:
                     type: boolean
                   downvoted:
                     type: boolean
+                  is_anonymous:
+                    type: string
 put:
   tags:
     - posts

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -86,8 +86,8 @@ define('forum/topic/postTools', [
 
     function addPostHandlers(tid) {
         const postContainer = components.get('topic');
-        console.assert(typeof(postContainer) == 'object');
-        console.assert(typeof(postContainer.on) === 'function');
+        console.assert(typeof postContainer === 'object');
+        console.assert(typeof postContainer.on === 'function');
 
         handleSelectionTooltip();
 
@@ -256,14 +256,14 @@ define('forum/topic/postTools', [
         });
 
         // handles what happens when an post/anonymize component is clicked
-        console.assert(typeof(postContainer) == 'object');
-        console.assert(typeof(postContainer.on) === 'function');
-        postContainer.on('click', '[component="post/anonymize"]', function () {     
+        console.assert(typeof postContainer === 'object');
+        console.assert(typeof postContainer.on === 'function');
+        postContainer.on('click', '[component="post/anonymize"]', function () {
             const pid = getData($(this), 'data-pid');
 
-            console.assert(typeof(pid) == 'string');
+            console.assert(typeof pid === 'string');
 
-            api["put"](`/posts/${pid}`, { pid: pid, is_anonymous: true, content: "" }, function (err) {
+            api.put(`/posts/${pid}`, { pid: pid, is_anonymous: true, content: '' }, function (err) {
                 if (err) {
                     return alerts.error(err);
                 }

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -87,6 +87,8 @@ define('forum/topic/postTools', [
 
     function addPostHandlers(tid) {
         const postContainer = components.get('topic');
+        console.assert(typeof(postContainer) == 'object');
+        console.assert(typeof(postContainer.on) === 'function');
 
         handleSelectionTooltip();
 
@@ -254,7 +256,10 @@ define('forum/topic/postTools', [
             openChat($(this));
         });
 
-        postContainer.on('click', '[component="post/anonymize"]', function () {
+        // handles what happens when an post/anonymize component is clicked
+        console.assert(typeof(postContainer) == 'object');
+        console.assert(typeof(postContainer.on) === 'function');
+        postContainer.on('click', '[component="post/anonymize"]', function () {            
             console.log("worked!");
         });
     }

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -259,8 +259,14 @@ define('forum/topic/postTools', [
         // handles what happens when an post/anonymize component is clicked
         console.assert(typeof(postContainer) == 'object');
         console.assert(typeof(postContainer.on) === 'function');
-        postContainer.on('click', '[component="post/anonymize"]', function () {            
-            console.log("worked!");
+        postContainer.on('click', '[component="post/anonymize"]', function () {     
+            const pid = getData($(this), 'data-pid');
+
+            api["put"](`/posts/${pid}`, { pid: pid, isAnonymous: true, content: "" }, function (err) {
+                if (err) {
+                    return alerts.error(err);
+                }
+            });
         });
     }
 

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -253,6 +253,10 @@ define('forum/topic/postTools', [
         postContainer.on('click', '[component="post/chat"]', function () {
             openChat($(this));
         });
+
+        postContainer.on('click', '[component="post/anonymize"]', function () {
+            console.log("worked!");
+        });
     }
 
     async function onReplyClicked(button, tid) {

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -262,7 +262,7 @@ define('forum/topic/postTools', [
         postContainer.on('click', '[component="post/anonymize"]', function () {     
             const pid = getData($(this), 'data-pid');
 
-            api["put"](`/posts/${pid}`, { pid: pid, isAnonymous: true, content: "" }, function (err) {
+            api["put"](`/posts/${pid}`, { pid: pid, is_anonymous: true, content: "" }, function (err) {
                 if (err) {
                     return alerts.error(err);
                 }

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { assert } = require('../../../../src/middleware');
+
 
 define('forum/topic/postTools', [
     'share',
@@ -261,6 +263,8 @@ define('forum/topic/postTools', [
         console.assert(typeof(postContainer.on) === 'function');
         postContainer.on('click', '[component="post/anonymize"]', function () {     
             const pid = getData($(this), 'data-pid');
+
+            console.assert(typeof(pid) == 'string');
 
             api["put"](`/posts/${pid}`, { pid: pid, is_anonymous: true, content: "" }, function (err) {
                 if (err) {

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const { assert } = require('../../../../src/middleware');
-
-
 define('forum/topic/postTools', [
     'share',
     'navigator',

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -263,7 +263,7 @@ define('forum/topic/postTools', [
 
             console.assert(typeof pid === 'string');
 
-            api.put(`/posts/${pid}`, { pid: pid, is_anonymous: true, content: '' }, function (err) {
+            api.put(`/posts/${pid}`, { pid: pid, is_anonymous: 'true', content: '' }, function (err) {
                 if (err) {
                     return alerts.error(err);
                 }

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -43,11 +43,11 @@ postsAPI.get = async function (caller, data) {
 };
 
 postsAPI.edit = async function (caller, data) {
-    if(data.hasOwnProperty("is_anonymous")) {
-        console.assert(data.hasOwnProperty(pid));
-        console.assert(typeof(data.pid) == 'string');
-        console.assert(typeof(data.is_anonymous) == 'boolean');
-        await posts.setPostField(data.pid, "is_anonymous", data.is_anonymous);
+    if (data.hasOwnProperty('is_anonymous')) {
+        console.assert(data.hasOwnProperty('pid'));
+        console.assert(typeof data.pid === 'string');
+        console.assert(typeof data.is_anonymous === 'boolean');
+        await posts.setPostField(data.pid, 'is_anonymous', data.is_anonymous);
 
         return {};
     }

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -43,8 +43,8 @@ postsAPI.get = async function (caller, data) {
 };
 
 postsAPI.edit = async function (caller, data) {
-    if(data.hasOwnProperty("isAnonymous")) {
-        await posts.setPostField(data.pid, "isAnonymous", data.isAnonymous);
+    if(data.hasOwnProperty("is_anonymous")) {
+        await posts.setPostField(data.pid, "is_anonymous", data.is_anonymous);
 
         return {};
     }

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -44,6 +44,9 @@ postsAPI.get = async function (caller, data) {
 
 postsAPI.edit = async function (caller, data) {
     if(data.hasOwnProperty("is_anonymous")) {
+        console.assert(data.hasOwnProperty(pid));
+        console.assert(typeof(data.pid) == 'string');
+        console.assert(typeof(data.is_anonymous) == 'boolean');
         await posts.setPostField(data.pid, "is_anonymous", data.is_anonymous);
 
         return {};

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -46,7 +46,7 @@ postsAPI.edit = async function (caller, data) {
     if (data.hasOwnProperty('is_anonymous')) {
         console.assert(data.hasOwnProperty('pid'));
         console.assert(typeof data.pid === 'string');
-        console.assert(typeof data.is_anonymous === 'boolean');
+        console.assert(typeof data.is_anonymous === 'string');
         await posts.setPostField(data.pid, 'is_anonymous', data.is_anonymous);
 
         return {};

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -43,6 +43,12 @@ postsAPI.get = async function (caller, data) {
 };
 
 postsAPI.edit = async function (caller, data) {
+    if(data.hasOwnProperty("isAnonymous")) {
+        await posts.setPostField(data.pid, "isAnonymous", data.isAnonymous);
+
+        return {};
+    }
+
     if (!data || !data.pid || (meta.config.minimumPostLength !== 0 && !data.content)) {
         throw new Error('[[error:invalid-data]]');
     }

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -47,6 +47,8 @@ module.exports = function (Posts) {
             postData.handle = data.handle;
         }
 
+        postData.isAnonymous = false;
+
         let result = await plugins.hooks.fire('filter:post.create', { post: postData, data: data });
         postData = result.post;
         await db.setObject(`post:${postData.pid}`, postData);

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -47,7 +47,7 @@ module.exports = function (Posts) {
             postData.handle = data.handle;
         }
 
-        postData.isAnonymous = false;
+        postData.is_anonymous = false;
 
         let result = await plugins.hooks.fire('filter:post.create', { post: postData, data: data });
         postData = result.post;

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -47,7 +47,7 @@ module.exports = function (Posts) {
             postData.handle = data.handle;
         }
 
-        postData.is_anonymous = false;
+        postData.is_anonymous = '';
 
         let result = await plugins.hooks.fire('filter:post.create', { post: postData, data: data });
         postData = result.post;

--- a/src/posts/create.ts
+++ b/src/posts/create.ts
@@ -1,62 +1,84 @@
-"use strict";
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-const _ = require("lodash");
-const meta = require("../meta");
-const db = require("../database");
-const plugins = require("../plugins");
-const user = require("../user");
-const topics = require("../topics");
-const categories = require("../categories");
-const groups = require("../groups");
-const utils = require("../utils");
-module.exports = function (Posts) {
-    function addReplyTo(postData, timestamp) {
-        return __awaiter(this, void 0, void 0, function* () {
-            if (!postData.toPid) {
-                return;
-            }
-            yield Promise.all([
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                db.sortedSetAdd(`pid:${postData.toPid}:replies`, timestamp, postData.pid),
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                db.incrObjectField(`post:${postData.toPid}`, 'replies'),
-            ]);
-        });
+// Referenced @TevinWang’s TypeScript translation from P1: https://github.com/CMU-313/NodeBB/pull/23
+import _ = require('lodash');
+
+import meta = require('../meta');
+import db = require('../database');
+import plugins = require('../plugins');
+import user = require('../user');
+import topics = require('../topics');
+import categories = require('../categories');
+import groups = require('../groups');
+import utils = require('../utils');
+
+type CreateData = {
+  content?: string;
+  timestamp?: number | Date;
+  isMain?: boolean;
+  toPid?: string;
+  ip?: string;
+  handle?: string;
+  uid?: string;
+  tid?: string;
+}
+
+type PostData = {
+  toPid?: string;
+  handle?: string;
+  isMain?: boolean;
+  ip?: string;
+  pid: string;
+  uid: string;
+  tid: string;
+  cid?: string;
+  content: string;
+  timestamp: number | Date;
+  is_anonymous?: string;
+}
+
+module.exports = function (Posts: { create: (data: CreateData) => Promise<unknown>, uploads:
+{ sync: (pid: string) => unknown } }) {
+    async function addReplyTo(postData: PostData, timestamp: number | Date) {
+        if (!postData.toPid) {
+            return;
+        }
+        await Promise.all([
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            db.sortedSetAdd(`pid:${postData.toPid}:replies`, timestamp, postData.pid),
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            db.incrObjectField(`post:${postData.toPid}`, 'replies'),
+        ]);
     }
-    Posts.create = (data) => __awaiter(this, void 0, void 0, function* () {
+    Posts.create = async (data: CreateData) => {
         // This is an internal method, consider using Topics.reply instead
         const { uid } = data;
         const { tid } = data;
         const content = data.content.toString();
         const timestamp = data.timestamp || Date.now();
         const isMain = data.isMain || false;
+
         if (!uid && parseInt(uid, 10) !== 0) {
             throw new Error('[[error:invalid-uid]]');
         }
+
         if (data.toPid && !utils.isNumber(data.toPid)) {
             throw new Error('[[error:invalid-pid]]');
         }
+
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        const pid = yield db.incrObjectField('global', 'nextPid');
-        let postData = {
+        const pid: string = await db.incrObjectField('global', 'nextPid') as string;
+
+        let postData: PostData = {
             pid: pid,
             uid: uid,
             tid: tid,
             content: content,
             timestamp: timestamp,
         };
+
         if (data.toPid) {
             postData.toPid = data.toPid;
         }
+
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         if (data.ip && meta.config.trackIpPerPost) {
             postData.ip = data.ip;
@@ -64,15 +86,20 @@ module.exports = function (Posts) {
         if (data.handle && !parseInt(uid, 10)) {
             postData.handle = data.handle;
         }
+
         postData.is_anonymous = '';
-        let result = yield plugins.hooks.fire('filter:post.create', { post: postData, data: data });
+
+        let result: { post: PostData } = await plugins.hooks.fire('filter:post.create', { post: postData, data: data }) as { post : PostData };
         postData = result.post;
+
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        yield db.setObject(`post:${postData.pid}`, postData);
+        await db.setObject(`post:${postData.pid}`, postData);
+
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        const topicData = yield topics.getTopicFields(tid, ['cid', 'pinned']);
+        const topicData: { cid?: string, pinned: boolean } = await topics.getTopicFields(tid, ['cid', 'pinned']) as { cid?: string, pinned: boolean };
         postData.cid = topicData.cid;
-        yield Promise.all([
+
+        await Promise.all([
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             db.sortedSetAdd('posts:pid', timestamp, postData.pid),
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
@@ -88,9 +115,10 @@ module.exports = function (Posts) {
             addReplyTo(postData, timestamp),
             Posts.uploads.sync(postData.pid),
         ]);
-        result = (yield plugins.hooks.fire('filter:post.get', { post: postData, uid: data.uid }));
+
+        result = await plugins.hooks.fire('filter:post.get', { post: postData, uid: data.uid }) as { post: PostData };
         result.post.isMain = isMain;
-        plugins.hooks.fire('action:post.save', { post: _.clone(result.post) }).catch((e) => console.error(e));
+        plugins.hooks.fire('action:post.save', { post: _.clone(result.post) }).catch((e: Error) => console.error(e));
         return result.post;
-    });
+    };
 };

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -7,7 +7,7 @@ const utils = require('../utils');
 const intFields = [
     'uid', 'pid', 'tid', 'deleted', 'timestamp',
     'upvotes', 'downvotes', 'deleterUid', 'edited',
-    'replies', 'bookmarks', 'anonymous'
+    'replies', 'bookmarks',
 ];
 
 module.exports = function (Posts) {

--- a/src/posts/summary.js
+++ b/src/posts/summary.js
@@ -44,10 +44,7 @@ module.exports = function (Posts) {
             if (!uidToUser.hasOwnProperty(post.uid)) {
                 post.uid = 0;
             }
-            if (!post.anonymous && post.uid === 0) {
-                post.user = uidToUser[post.uid];
-            }
-            else { post.user = "Anonymous" }
+            post.user = uidToUser[post.uid];
             Posts.overrideGuestHandle(post, post.handle);
             post.handle = undefined;
             post.topic = tidToTopic[post.tid];

--- a/src/posts/user.js
+++ b/src/posts/user.js
@@ -140,7 +140,7 @@ module.exports = function (Posts) {
             throw new Error('[[error:no-user]]');
         }
         let postData = await Posts.getPostsFields(pids, [
-            'pid', 'tid', 'uid', 'content', 'deleted', 'timestamp', 'upvotes', 'downvotes', 'anonymous'
+            'pid', 'tid', 'uid', 'content', 'deleted', 'timestamp', 'upvotes', 'downvotes',
         ]);
         postData = postData.filter(p => p.pid && p.uid !== parseInt(toUid, 10));
         pids = postData.map(p => p.pid);

--- a/themes/nodebb-theme-persona/templates/partials/topic/post-menu-list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post-menu-list.tpl
@@ -83,6 +83,11 @@
             <span component="post/bookmark-count" class="bookmarkCount badge" data-bookmarks="{posts.bookmarks}">{posts.bookmarks}</span>&nbsp;
         </a>
     </li>
+    <li>
+        <a component="post/anonymize" role="menuitem" tabindex="-1" href="#">
+            <span class="anonymize-text">[[topic:anonymize]]</span>
+        </a>
+    </li>
     {{{ end }}}
 
     <li>

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -1,5 +1,5 @@
 <div class="clearfix post-header">
-    <!-- IF !posts.anonymous -->
+    <!-- IF !posts.is_anonymous -->
      <div class="icon pull-left">
          <a href="<!-- IF posts.user.userslug -->{config.relative_path}/user/{posts.user.userslug}<!-- ELSE -->#<!-- ENDIF posts.user.userslug -->">
             {buildAvatar(posts.user, "sm2x", true, "", "user/picture")}
@@ -10,7 +10,7 @@
 
     <small class="pull-left">
         <strong>
-        <!-- IF posts.anonymous -->
+        <!-- IF posts.is_anonymous -->
             <p itemprop="author">Anonymous</p>
         <!-- ELSE -->
             <a href="{config.relative_path}/user/{posts.user.userslug}" itemprop="author" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>


### PR DESCRIPTION
Resolves #13
Resolves #16
Resolves #17
Resolves #23 

PR overview:
Adds a button to the post options dropup that sets a post to anonymous. On reload, the username will display "anonymous" instead of the poster's username.

Changes made:
- src/posts/create.js
     - added is_anonymous to postData for creation
     - set to false by default
 - public/src/client/topic/postTools.js
     - added function to post/anonymize component to update is_anonymous field for post on click
 - themes/nodebb-theme-persona/templates/partials/topic/post-menu-list.tpl
     - added anonymize button to post options dropup
 - themes/nodebb-theme-persona/templates/partials/topic/post.tpl
     - removed profile picture for anonymous users
     - added change username to "anonymous" if post is marked as anonymous
 - src/api/posts.js
     - modified edit api method to check if it is editing is_anonymous, and if it is just sets it to true and skips rest of API call
 - public/openapi/write/posts/pid.yaml
     - updated post GET api schema

Testing:
- made a new post, clicked the button, and reloaded the page to check if the username was "anonymous" on 2 posts