### PR TITLE
Create functionality to de-anonymize a post after it's been anonymized

### DIFF
--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -275,9 +275,7 @@ define('forum/topic/postTools', [
                         }
                     });
                 }
-            }); 
-
-            
+            });
         });
     }
 

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -264,10 +264,12 @@ define('forum/topic/postTools', [
             console.assert(typeof pid === 'string');
 
             api.get(`/posts/${pid}`, {}).then((post) => {
-                console.assert(typeof post === 'object');
                 if (post) {
-                    let anonymous = 'true';
+                    console.assert(typeof post === 'object');
+                    console.assert(post.hasOwnProperty('is_anonymous'));
                     console.assert(typeof post.is_anonymous === 'string');
+
+                    let anonymous = 'true';
                     if (post.is_anonymous === 'true') {
                         anonymous = 'false';
                     }

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -264,8 +264,10 @@ define('forum/topic/postTools', [
             console.assert(typeof pid === 'string');
 
             api.get(`/posts/${pid}`, {}).then((post) => {
+                console.assert(typeof post === 'object');
                 if (post) {
                     let anonymous = 'true';
+                    console.assert(typeof post.is_anonymous === 'string');
                     if (post.is_anonymous === 'true') {
                         anonymous = 'false';
                     }

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -263,11 +263,21 @@ define('forum/topic/postTools', [
 
             console.assert(typeof pid === 'string');
 
-            api.put(`/posts/${pid}`, { pid: pid, is_anonymous: 'true', content: '' }, function (err) {
-                if (err) {
-                    return alerts.error(err);
+            api.get(`/posts/${pid}`, {}).then((post) => {
+                if (post) {
+                    let anonymous = 'true';
+                    if (post.is_anonymous === 'true') {
+                        anonymous = 'false';
+                    }
+                    api.put(`/posts/${pid}`, { pid: pid, is_anonymous: anonymous, content: '' }, function (err) {
+                        if (err) {
+                            return alerts.error(err);
+                        }
+                    });
                 }
-            });
+            }); 
+
+            
         });
     }
 

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -9,6 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+// Referenced @TevinWang’s TypeScript translation from P1: https://github.com/CMU-313/NodeBB/pull/23
 const _ = require("lodash");
 const meta = require("../meta");
 const db = require("../database");

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -65,7 +65,7 @@ module.exports = function (Posts) {
         if (data.handle && !parseInt(uid, 10)) {
             postData.handle = data.handle;
         }
-        postData.is_anonymous = '';
+        postData.is_anonymous = 'false';
         let result = yield plugins.hooks.fire('filter:post.create', { post: postData, data: data });
         postData = result.post;
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call

--- a/src/posts/create.ts
+++ b/src/posts/create.ts
@@ -87,7 +87,7 @@ module.exports = function (Posts: { create: (data: CreateData) => Promise<unknow
             postData.handle = data.handle;
         }
 
-        postData.is_anonymous = '';
+        postData.is_anonymous = 'false';
 
         let result: { post: PostData } = await plugins.hooks.fire('filter:post.create', { post: postData, data: data }) as { post : PostData };
         postData = result.post;

--- a/themes/nodebb-theme-persona/templates/partials/topic/post-menu-list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post-menu-list.tpl
@@ -84,15 +84,9 @@
         </a>
     </li>
     <li>
-        {{{ if (posts.is_anonymous == "true") }}}
-            <a component="post/anonymize" role="menuitem" tabindex="-1" href="#">
-                <span class="anonymize-text">[[topic:de_anonymize]]</span>
-            </a>
-        {{{ else }}}
-            <a component="post/anonymize" role="menuitem" tabindex="-1" href="#">
-                <span class="anonymize-text">[[topic:anonymize]]</span>
-            </a>
-        {{{ end }}}
+        <a component="post/anonymize" role="menuitem" tabindex="-1" href="#">
+            <span class="anonymize-text">[[topic:anonymize]]</span>
+        </a>
     </li>
     {{{ end }}}
 

--- a/themes/nodebb-theme-persona/templates/partials/topic/post-menu-list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post-menu-list.tpl
@@ -84,13 +84,15 @@
         </a>
     </li>
     <li>
-        <a component="post/anonymize" role="menuitem" tabindex="-1" href="#">
-            {{{ if (posts.is_anonymous == "true") }}}
-                <span class="anonymize-text">[[topic:anonymize]]</span>
-            {{{ else }}}
+        {{{ if (posts.is_anonymous == "true") }}}
+            <a component="post/anonymize" role="menuitem" tabindex="-1" href="#">
                 <span class="anonymize-text">[[topic:de_anonymize]]</span>
-            {{{ end }}}
-        </a>
+            </a>
+        {{{ else }}}
+            <a component="post/anonymize" role="menuitem" tabindex="-1" href="#">
+                <span class="anonymize-text">[[topic:anonymize]]</span>
+            </a>
+        {{{ end }}}
     </li>
     {{{ end }}}
 

--- a/themes/nodebb-theme-persona/templates/partials/topic/post-menu-list.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post-menu-list.tpl
@@ -85,7 +85,11 @@
     </li>
     <li>
         <a component="post/anonymize" role="menuitem" tabindex="-1" href="#">
-            <span class="anonymize-text">[[topic:anonymize]]</span>
+            {{{ if (posts.is_anonymous == "true") }}}
+                <span class="anonymize-text">[[topic:anonymize]]</span>
+            {{{ else }}}
+                <span class="anonymize-text">[[topic:de_anonymize]]</span>
+            {{{ end }}}
         </a>
     </li>
     {{{ end }}}

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -1,20 +1,20 @@
 <div class="clearfix post-header">
-    <!-- IF !posts.is_anonymous -->
+    {{{ if (posts.is_anonymous == "false") }}}
      <div class="icon pull-left">
          <a href="<!-- IF posts.user.userslug -->{config.relative_path}/user/{posts.user.userslug}<!-- ELSE -->#<!-- ENDIF posts.user.userslug -->">
             {buildAvatar(posts.user, "sm2x", true, "", "user/picture")}
             <i component="user/status" class="fa fa-circle status {posts.user.status}" title="[[global:{posts.user.status}]]"></i>
         </a>
     </div>
-     <!-- ENDIF -->
+    {{{ end }}}
 
     <small class="pull-left">
         <strong>
-        <!-- IF posts.is_anonymous -->
+        {{{ if (posts.is_anonymous == "true") }}}
             <p itemprop="author">Anonymous</p>
-        <!-- ELSE -->
+        {{{ else }}}
             <a href="{config.relative_path}/user/{posts.user.userslug}" itemprop="author" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
-        <!-- ENDIF -->
+        {{{ end }}}
         </strong>
 
         <!-- IMPORT partials/topic/badge.tpl -->


### PR DESCRIPTION
Resolves #29 

PR overview:
Changes functionality of anonymize button in posts dropdown so that it also includes de-anonymizing a post if the post is already anonymous. 

Changes made:
'public/src/client/topic/postTools.js'
- creates anonymous variable for value of current post state of is_anonymous
- sets anonymous to the opposite of is_anonymous
- sends an api call to update the post with the new state of is_anonymous
'src/posts/create.js'
- adds a code comment to give credit because for some reason this wasn't automatically merged in when I pulled the latest from main before creating this branch
'themes/nodebb-theme-persona/templates/partials/topic/post.tpl'
- updates the if else statements checking for anonymous to check for the value of is_anonymous and not its existence in order to show/not show the profile picture and name of the user

Testing:
- created new post, clicked anonymize button, reloaded page, then repeated to see if the username switched back and forth from anonymous on two posts