### PR TITLE
Added window reload after user clicks 'anonymize' button

### DIFF
--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -114,7 +114,6 @@ define('forum/topic/postTools', [
         });
 
         postContainer.on('click', '[component="post/bookmark"]', function () {
-            console.log('what');
             return bookmarkPost($(this), getData($(this), 'data-pid'));
         });
 
@@ -260,7 +259,6 @@ define('forum/topic/postTools', [
         console.assert(typeof postContainer === 'object');
         console.assert(typeof postContainer.on === 'function');
         postContainer.on('click', '[component="post/anonymize"]', function () {
-            console.log('what');
             const pid = getData($(this), 'data-pid');
             console.assert(typeof pid === 'string');
             api.get(`/posts/${pid}`, {}).then((post) => {

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -114,6 +114,7 @@ define('forum/topic/postTools', [
         });
 
         postContainer.on('click', '[component="post/bookmark"]', function () {
+            console.log('what');
             return bookmarkPost($(this), getData($(this), 'data-pid'));
         });
 
@@ -259,10 +260,14 @@ define('forum/topic/postTools', [
         console.assert(typeof postContainer === 'object');
         console.assert(typeof postContainer.on === 'function');
         postContainer.on('click', '[component="post/anonymize"]', function () {
+            console.log('what');
             const pid = getData($(this), 'data-pid');
-
             console.assert(typeof pid === 'string');
-
+            // api.put(`/posts/${pid}`, { pid: pid, is_anonymous: 'true', content: '' }, function (err) {
+            //     if (err) {
+            //         return alerts.error(err);
+            //     }
+            // });
             api.get(`/posts/${pid}`, {}).then((post) => {
                 if (post) {
                     console.assert(typeof post === 'object');

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -263,11 +263,6 @@ define('forum/topic/postTools', [
             console.log('what');
             const pid = getData($(this), 'data-pid');
             console.assert(typeof pid === 'string');
-            // api.put(`/posts/${pid}`, { pid: pid, is_anonymous: 'true', content: '' }, function (err) {
-            //     if (err) {
-            //         return alerts.error(err);
-            //     }
-            // });
             api.get(`/posts/${pid}`, {}).then((post) => {
                 if (post) {
                     console.assert(typeof post === 'object');
@@ -282,6 +277,7 @@ define('forum/topic/postTools', [
                         if (err) {
                             return alerts.error(err);
                         }
+                        window.location.reload();
                     });
                 }
             });

--- a/src/posts/summary.js
+++ b/src/posts/summary.js
@@ -20,7 +20,7 @@ module.exports = function (Posts) {
         options.parse = options.hasOwnProperty('parse') ? options.parse : true;
         options.extraFields = options.hasOwnProperty('extraFields') ? options.extraFields : [];
 
-        const fields = ['pid', 'tid', 'content', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle', 'anonymous'].concat(options.extraFields);
+        const fields = ['pid', 'tid', 'content', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle'].concat(options.extraFields);
 
         let posts = await Posts.getPostsFields(pids, fields);
         posts = posts.filter(Boolean);

--- a/src/posts/summary.js
+++ b/src/posts/summary.js
@@ -20,7 +20,7 @@ module.exports = function (Posts) {
         options.parse = options.hasOwnProperty('parse') ? options.parse : true;
         options.extraFields = options.hasOwnProperty('extraFields') ? options.extraFields : [];
 
-        const fields = ['pid', 'tid', 'content', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle'].concat(options.extraFields);
+        const fields = ['pid', 'tid', 'content', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle', 'anonymous'].concat(options.extraFields);
 
         let posts = await Posts.getPostsFields(pids, fields);
         posts = posts.filter(Boolean);


### PR DESCRIPTION
Resolves #28 

PR overview:
The window is automatically reloaded when the user clicks the anonymize button so that the user doesn't need to manually refresh. 

Changes made:
'public/src/client/topic/postTools.js'

- added window.location.reload() function after ensuring that anonymizing the post causes no errors 


Testing:

created new post, clicked anonymize button, waited to see "Anonymous" name replacing the user's username, then repeated to see if the username switched back and forth from anonymous