### PR TITLE
Fixed the formatting on UserGuide.md

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -1,15 +1,15 @@
-Feature: Make a post anonymous
-How to use the feature:
-    Making a post anonymous:
+# Feature: Make a post anonymous
+## How to use the feature:
+- Making a post anonymous:
     - make a new post or open an existing post
     - click the post drop down button to access the post tools
     - click the anonymize button in the post tools list
-    Changing an anonymous post to no longer be anonymous:
+- Changing an anonymous post to no longer be anonymous:
     - go to an existing post that is anonymous
     - click the post drop down button to access the post tools
     - click the deanonymize button in the post tools list
 
-Testing:
-    Link: 
-    [Explain what is being tested]
-    [These tests are sufficient because...]
+## Testing:
+- Link: 
+    - [Explain what is being tested]
+    - [These tests are sufficient because...]


### PR DESCRIPTION
Original issue: text was in one big block because of weird markdown formatting needing \\'s at the end of lines or lists/headers
Fix: Turned some things into headers and everything else to lists (see image below)

<img width="432" alt="image" src="https://github.com/CMU-313/spring24-nodebb-team-garden/assets/40529960/4213443c-9053-4695-bcad-ce0f1906c4b1">
