### PR TITLE
Added coverage for 'Anonymous' feature

### DIFF
--- a/test/posts.js
+++ b/test/posts.js
@@ -645,7 +645,6 @@ describe('Post\'s', () => {
                 cid: cid,
                 title: 'topic to make anonymous',
                 content: 'A post to make anonymous',
-                is_anonymous: 'true',
                 tags: ['nodebb'],
             }, (err, data) => {
                 assert.ifError(err);
@@ -653,6 +652,11 @@ describe('Post\'s', () => {
                 tid = data.topicData.tid;
                 done();
             });
+        });
+
+        it('should default is_anonymous tag to false', async () => {
+            const defaultPost = await apiPosts.get({ uid: voterUid }, { pid: pid, content: 'A post to make anonymous', tid: tid });
+            assert.strictEqual(defaultPost.is_anonymous, 'false');
         });
 
         it('should save the anonymous status of a post', async () => {

--- a/test/posts.js
+++ b/test/posts.js
@@ -637,28 +637,6 @@ describe('Post\'s', () => {
         });
     });
     describe('anonymize', () => {
-        // async function createAnonymousPost() {
-           
-        //     const postData = await topics.post({
-        //         uid: voterUid,
-        //         cid: cid,
-        //         title: 'test topic',
-        //         content: 'test anonymous post content',
-        //         is_anonymous: 'false'
-        //     });
-        //     return postData;
-        // }
-        // let pid;
-        // let uid;
-        // let content;
-
-        // before(async () => {
-        //     const postData = await createAnonymousPost();
-        //     uid = postData.uid;
-        //     pid = postData.pid;
-        //     content = postData.content;
-        // });
-
         let pid;
         let tid;
         before((done) => {
@@ -673,18 +651,15 @@ describe('Post\'s', () => {
                 assert.ifError(err);
                 pid = data.postData.pid;
                 tid = data.topicData.tid;
-                done()
+                done();
             });
         });
 
-        it ('should anonymize a post', async () => {
-            await apiPosts.edit({ uid: voterUid }, { pid: pid, content: 'A post to make anonymous', tid: tid });
-            const editedPost = await apiPosts.get({ uid: voterUid }, { pid: pid, content: 'A post to make anonymous', tid: tid });
+        it('should save the anonymous status of a post', async () => {
+            await apiPosts.edit({ uid: voterUid }, { pid: pid, content: 'A post to make anonymous', tid: tid, is_anonymous: 'true'});
+            const editedPost = await apiPosts.get({ uid: voterUid }, { pid: pid, content: 'A post to make anonymous', tid: tid});
             assert.strictEqual(editedPost.is_anonymous, 'true');
-            done();
         });
-        
-
     });
 
     describe('move', () => {

--- a/test/posts.js
+++ b/test/posts.js
@@ -656,8 +656,8 @@ describe('Post\'s', () => {
         });
 
         it('should save the anonymous status of a post', async () => {
-            await apiPosts.edit({ uid: voterUid }, { pid: pid, content: 'A post to make anonymous', tid: tid, is_anonymous: 'true'});
-            const editedPost = await apiPosts.get({ uid: voterUid }, { pid: pid, content: 'A post to make anonymous', tid: tid});
+            await apiPosts.edit({ uid: voterUid }, { pid: pid, content: 'A post to make anonymous', tid: tid, is_anonymous: 'true' });
+            const editedPost = await apiPosts.get({ uid: voterUid }, { pid: pid, content: 'A post to make anonymous', tid: tid });
             assert.strictEqual(editedPost.is_anonymous, 'true');
         });
     });

--- a/test/posts.js
+++ b/test/posts.js
@@ -636,6 +636,56 @@ describe('Post\'s', () => {
             assert.strictEqual(data.content, 'A reply to edit');
         });
     });
+    describe('anonymize', () => {
+        // async function createAnonymousPost() {
+           
+        //     const postData = await topics.post({
+        //         uid: voterUid,
+        //         cid: cid,
+        //         title: 'test topic',
+        //         content: 'test anonymous post content',
+        //         is_anonymous: 'false'
+        //     });
+        //     return postData;
+        // }
+        // let pid;
+        // let uid;
+        // let content;
+
+        // before(async () => {
+        //     const postData = await createAnonymousPost();
+        //     uid = postData.uid;
+        //     pid = postData.pid;
+        //     content = postData.content;
+        // });
+
+        let pid;
+        let tid;
+        before((done) => {
+            topics.post({
+                uid: voterUid,
+                cid: cid,
+                title: 'topic to make anonymous',
+                content: 'A post to make anonymous',
+                is_anonymous: 'true',
+                tags: ['nodebb'],
+            }, (err, data) => {
+                assert.ifError(err);
+                pid = data.postData.pid;
+                tid = data.topicData.tid;
+                done()
+            });
+        });
+
+        it ('should anonymize a post', async () => {
+            await apiPosts.edit({ uid: voterUid }, { pid: pid, content: 'A post to make anonymous', tid: tid });
+            const editedPost = await apiPosts.get({ uid: voterUid }, { pid: pid, content: 'A post to make anonymous', tid: tid });
+            assert.strictEqual(editedPost.is_anonymous, 'true');
+            done();
+        });
+        
+
+    });
 
     describe('move', () => {
         let replyPid;


### PR DESCRIPTION
Resolves: #24 
PR overview:
Wrote a built-in test to prove that the is_anonymous tag is a valid property of posts that can be saved and retrieved.

Changes made:
'test/src/posts.js'

Testing:
Ensuring coverage % increased and all tests written run without crashing.