### PR TITLE
Adds extended anonymous functionality testing

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -9,7 +9,7 @@
     - go to an existing post that is anonymous
     - click the post drop down button to access the post tools
     - click the deanonymize button in the post tools list
-- Note: if dropdown is not appearing, rebuild NodeBB, or try replying to the post
+- Note: if dropdown or anonymize option is not appearing, rebuild NodeBB, refresh the page, or try making a new reply to the post
 
 ## Testing:
 - Link: test/posts.js, lines 640-679

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -1,15 +1,28 @@
 # Feature: Make a post anonymous
 ## How to use the feature:
+- start by logging in
 - Making a post anonymous:
-    - make a new post or open an existing post
+    - make a new post (may not work with old posts)
     - click the post drop down button to access the post tools
     - click the anonymize button in the post tools list
 - Changing an anonymous post to no longer be anonymous:
     - go to an existing post that is anonymous
     - click the post drop down button to access the post tools
     - click the deanonymize button in the post tools list
+- Note: if dropdown is not appearing, rebuild NodeBB, or try replying to the post
 
 ## Testing:
-- Link: 
-    - [Explain what is being tested]
-    - [These tests are sufficient because...]
+- Link: test/posts.js, lines 640-679
+    - We are testing editing the anonymous tag on newly created posts
+    - These automated tests are sufficient because they check that the anonymous tag can be changed to be true and false using the post.edit API call, which is the same logic that is used in public/src/client/topic/postTools.js to anonymize/deanonymize posts. The reason we do not use postTools.js directly to test is because it uses requireJS's define, which is not supported by mocha natively.
+- Visual testing:
+    - To visual test our feature, follow the steps above. Ensure that the following are true:
+        - when post is anonymous:
+            - username is "Anonymous"
+            - profile picture is gone
+            - button in post dropdown says "deanonymize"
+        - when post is not anonymous:
+            - username is username
+            - profile picture is there
+            - button in post dropdown says "anonymize"
+        - when anonymize/deanonymize button is clicked, window automatically reloads to reflect changes

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -9,7 +9,7 @@
     - go to an existing post that is anonymous
     - click the post drop down button to access the post tools
     - click the deanonymize button in the post tools list
-- Note: if dropdown or anonymize option is not appearing, rebuild NodeBB, refresh the page, or try making a new reply to the post
+- Note: if dropdown or anonymize option is not appearing, rebuild NodeBB, refresh the page (a few times), or try making a new reply to the post
 
 ## Testing:
 - Link: test/posts.js, lines 640-679

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -261,24 +261,7 @@ define('forum/topic/postTools', [
         postContainer.on('click', '[component="post/anonymize"]', function () {
             const pid = getData($(this), 'data-pid');
             console.assert(typeof pid === 'string');
-            api.get(`/posts/${pid}`, {}).then((post) => {
-                if (post) {
-                    console.assert(typeof post === 'object');
-                    console.assert(post.hasOwnProperty('is_anonymous'));
-                    console.assert(typeof post.is_anonymous === 'string');
-
-                    let anonymous = 'true';
-                    if (post.is_anonymous === 'true') {
-                        anonymous = 'false';
-                    }
-                    api.put(`/posts/${pid}`, { pid: pid, is_anonymous: anonymous, content: '' }, function (err) {
-                        if (err) {
-                            return alerts.error(err);
-                        }
-                        window.location.reload();
-                    });
-                }
-            });
+            anonymizePost(pid);
         });
     }
 
@@ -389,6 +372,33 @@ define('forum/topic/postTools', [
             hooks.fire(`action:post.${type}`, { pid: pid });
         });
         return false;
+    }
+
+
+    /**
+     * Anonymize/deanonymize a post with pid
+     * @param pid : string
+     */
+    function anonymizePost(pid) {
+        console.assert(typeof pid === 'string');
+        api.get(`/posts/${pid}`, {}).then((post) => {
+            if (post) {
+                console.assert(typeof post === 'object');
+                console.assert(post.hasOwnProperty('is_anonymous'));
+                console.assert(typeof post.is_anonymous === 'string');
+
+                let anonymous = 'true';
+                if (post.is_anonymous === 'true') {
+                    anonymous = 'false';
+                }
+                api.put(`/posts/${pid}`, { pid: pid, is_anonymous: anonymous, content: '' }, function (err) {
+                    if (err) {
+                        return alerts.error(err);
+                    }
+                    window.location.reload();
+                });
+            }
+        });
     }
 
     function getData(button, data) {

--- a/test/posts.js
+++ b/test/posts.js
@@ -23,6 +23,7 @@ const apiTopics = require('../src/api/topics');
 const meta = require('../src/meta');
 const file = require('../src/file');
 const helpers = require('./helpers');
+const pt = require('../public/src/client/topic/postTools');
 
 describe('Post\'s', () => {
     let voterUid;
@@ -660,7 +661,11 @@ describe('Post\'s', () => {
         });
 
         it('should save the anonymous status of a post', async () => {
-            await apiPosts.edit({ uid: voterUid }, { pid: pid, content: 'A post to make anonymous', tid: tid, is_anonymous: 'true' });
+            const defaultPost = await apiPosts.get({ uid: voterUid }, { pid: pid, content: 'A post to make anonymous', tid: tid });
+            assert.strictEqual(defaultPost.is_anonymous, 'false');
+            assert.strictEqual(defaultPost.pid, pid);
+            pt.anonymizePost(pid);
+            // await apiPosts.edit({ uid: voterUid }, { pid: pid, content: 'A post to make anonymous', tid: tid, is_anonymous: 'true' });
             const editedPost = await apiPosts.get({ uid: voterUid }, { pid: pid, content: 'A post to make anonymous', tid: tid });
             assert.strictEqual(editedPost.is_anonymous, 'true');
         });

--- a/test/posts.js
+++ b/test/posts.js
@@ -23,7 +23,6 @@ const apiTopics = require('../src/api/topics');
 const meta = require('../src/meta');
 const file = require('../src/file');
 const helpers = require('./helpers');
-const pt = require('../public/src/client/topic/postTools');
 
 describe('Post\'s', () => {
     let voterUid;
@@ -637,6 +636,7 @@ describe('Post\'s', () => {
             assert.strictEqual(data.content, 'A reply to edit');
         });
     });
+
     describe('anonymize', () => {
         let pid;
         let tid;
@@ -660,15 +660,22 @@ describe('Post\'s', () => {
             assert.strictEqual(defaultPost.is_anonymous, 'false');
         });
 
-        it('should save the anonymous status of a post', async () => {
+        it('should switch the anonymous status of a post back and forth', async () => {
             const defaultPost = await apiPosts.get({ uid: voterUid }, { pid: pid, content: 'A post to make anonymous', tid: tid });
             assert.strictEqual(defaultPost.is_anonymous, 'false');
             assert.strictEqual(defaultPost.pid, pid);
-            pt.anonymizePost(pid);
-            // await apiPosts.edit({ uid: voterUid }, { pid: pid, content: 'A post to make anonymous', tid: tid, is_anonymous: 'true' });
+
+            // turns is_anonymous to true
+            await apiPosts.edit({ uid: voterUid }, { pid: pid, content: 'A post to make anonymous', tid: tid, is_anonymous: 'true' });
             const editedPost = await apiPosts.get({ uid: voterUid }, { pid: pid, content: 'A post to make anonymous', tid: tid });
             assert.strictEqual(editedPost.is_anonymous, 'true');
+
+            // turns is_anonymous to false
+            await apiPosts.edit({ uid: voterUid }, { pid: pid, content: 'A post to make anonymous', tid: tid, is_anonymous: 'false' });
+            const editedPostFalse = await apiPosts.get({ uid: voterUid }, { pid: pid, content: 'A post to make anonymous', tid: tid });
+            assert.strictEqual(editedPostFalse.is_anonymous, 'false');
         });
+
     });
 
     describe('move', () => {

--- a/test/posts.js
+++ b/test/posts.js
@@ -675,7 +675,6 @@ describe('Post\'s', () => {
             const editedPostFalse = await apiPosts.get({ uid: voterUid }, { pid: pid, content: 'A post to make anonymous', tid: tid });
             assert.strictEqual(editedPostFalse.is_anonymous, 'false');
         });
-
     });
 
     describe('move', () => {


### PR DESCRIPTION
Resolves #38 
PR overview:
Tests that the is_anonymous tag for a post can be set to true and false.

Changes made:
'test/src/posts.js'
- adds test to make sure after is_anonymous tag on a post is set to true, it can be turned back to false
'UserGuide.md'
- updates to explain testing
- adds more explanation of functionality
'public/src/client/topic/postTools.js'
- moves logic updating is_anonymous to its own function

Testing:
Ensuring coverage % increased and all tests written run without failing.